### PR TITLE
do not pretend to return a value. it's always nil at this point

### DIFF
--- a/iavl_node.go
+++ b/iavl_node.go
@@ -336,10 +336,9 @@ func (node *IAVLNode) remove(t *IAVLTree, key []byte) (
 			node.rightHash, node.rightNode = newRightHash, newRightNode
 			if newKey != nil {
 				node.key = newKey
-				newKey = nil
 			}
 			node.calcHeightAndSize(t)
-			return nil, node.balance(t), newKey, value, true
+			return nil, node.balance(t), nil, value, true
 		}
 	}
 }


### PR DESCRIPTION
Line 342 reads as if we could actually return a value for "newKey" but the flow guarantees that it is `nil` at this point. It mainly a cosmetic change to aid in reading / porting the code.
