### PR TITLE
Orphans keep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,6 @@ test:
 
 get_deps:
 	go get github.com/tendermint/go-merkle/...
+
+bench:
+	go test github.com/tendermint/go-merkle/... -tags gcc -bench=.

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -395,7 +395,7 @@ func TestIAVLProof(t *testing.T) {
 func BenchmarkImmutableAvlTreeLevelDB(b *testing.B) {
 	b.StopTimer()
 
-	db := db.NewDB("test", db.GoLevelDBBackendStr, "./")
+	db := db.NewDB("test", db.CLevelDBBackendStr, "./")
 	t := NewIAVLTree(100000, db)
 	// for i := 0; i < 10000000; i++ {
 	for i := 0; i < 1000000; i++ {

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -392,10 +392,10 @@ func TestIAVLProof(t *testing.T) {
 
 }
 
-func BenchmarkImmutableAvlTreeLevelDB2(b *testing.B) {
+func BenchmarkImmutableAvlTreeLevelDB(b *testing.B) {
 	b.StopTimer()
 
-	db := db.NewDB("test", "leveldb2", "./")
+	db := db.NewDB("test", db.GoLevelDBBackendStr, "./")
 	t := NewIAVLTree(100000, db)
 	// for i := 0; i < 10000000; i++ {
 	for i := 0; i < 1000000; i++ {
@@ -427,7 +427,7 @@ func BenchmarkImmutableAvlTreeLevelDB2(b *testing.B) {
 func BenchmarkImmutableAvlTreeMemDB(b *testing.B) {
 	b.StopTimer()
 
-	db := db.NewDB("test", "memdb", "")
+	db := db.NewDB("test", db.MemDBBackendStr, "")
 	t := NewIAVLTree(100000, db)
 	// for i := 0; i < 10000000; i++ {
 	for i := 0; i < 1000000; i++ {

--- a/scripts/looper.go
+++ b/scripts/looper.go
@@ -11,9 +11,7 @@ import (
 func main() {
 
 	db := db.NewMemDB()
-	_, walDir := Tempdir("looper.wal.")
-	fmt.Println("WAL dir: ", walDir)
-	t := merkle.NewIAVLTree(0, walDir, db)
+	t := merkle.NewIAVLTree(0, db)
 	// 23000ns/op, 43000ops/s
 	// for i := 0; i < 10000000; i++ {
 	// for i := 0; i < 1000000; i++ {


### PR DESCRIPTION
This keeps orphans around for 1 more block.

Before, orphans used to get deleted before saving new nodes.

```
Height H Batch: [orphan_delete_H, orphan_delete_H, ... save_node_H, save_node_H]
```

Now these orphan_deletes happen in the next height, after save_node...

```
Height H Batch: [save_node_H, save_node_H, ... orphan_delete_H-1, orphan_delete_H-1]
Height H+1 Batch: [save_node_H+1, save_node_H+1, ... orphan_delete_H, orphan_delete_H]
```
