### PR TITLE
Iterate through part of tree (range of keys)

### DIFF
--- a/iavl_node.go
+++ b/iavl_node.go
@@ -447,35 +447,17 @@ func (node *IAVLNode) balance(t *IAVLTree) (newSelf *IAVLNode) {
 	return node
 }
 
-func (node *IAVLNode) traverse(t *IAVLTree, cb func(*IAVLNode) bool) bool {
-	stop := cb(node)
-	if stop {
-		return stop
-	}
-	if node.height > 0 {
-		stop = node.getLeftNode(t).traverse(t, cb)
-		if stop {
-			return stop
-		}
-		stop = node.getRightNode(t).traverse(t, cb)
-		if stop {
-			return stop
-		}
-	}
-	return false
-}
-
-func (node *IAVLNode) fitsStart(start []byte) bool {
-	return (start == nil || bytes.Compare(start, node.key) <= 0)
-}
-
-func (node *IAVLNode) fitsEnd(end []byte) bool {
-	return (end == nil || bytes.Compare(node.key, end) <= 0)
+// traverse is a wrapper over traverseInRange when we want the whole tree
+func (node *IAVLNode) traverse(t *IAVLTree, ascending bool, cb func(*IAVLNode) bool) bool {
+	return node.traverseInRange(t, nil, nil, ascending, cb)
 }
 
 func (node *IAVLNode) traverseInRange(t *IAVLTree, start, end []byte, ascending bool, cb func(*IAVLNode) bool) bool {
+	afterStart := (start == nil || bytes.Compare(start, node.key) <= 0)
+	beforeEnd := (end == nil || bytes.Compare(node.key, end) <= 0)
+
 	stop := false
-	if node.fitsStart(start) && node.fitsEnd(end) {
+	if afterStart && beforeEnd {
 		// IterateRange ignores this if not leaf
 		stop = cb(node)
 	}
@@ -486,24 +468,24 @@ func (node *IAVLNode) traverseInRange(t *IAVLTree, start, end []byte, ascending 
 	if node.height > 0 {
 		if ascending {
 			// check lower nodes, then higher
-			if node.fitsStart(start) {
+			if afterStart {
 				stop = node.getLeftNode(t).traverseInRange(t, start, end, ascending, cb)
 			}
 			if stop {
 				return stop
 			}
-			if node.fitsEnd(end) {
+			if beforeEnd {
 				stop = node.getRightNode(t).traverseInRange(t, start, end, ascending, cb)
 			}
 		} else {
 			// check the higher nodes first
-			if node.fitsEnd(end) {
+			if beforeEnd {
 				stop = node.getRightNode(t).traverseInRange(t, start, end, ascending, cb)
 			}
 			if stop {
 				return stop
 			}
-			if node.fitsStart(start) {
+			if afterStart {
 				stop = node.getLeftNode(t).traverseInRange(t, start, end, ascending, cb)
 			}
 		}

--- a/iavl_node.go
+++ b/iavl_node.go
@@ -465,6 +465,38 @@ func (node *IAVLNode) traverse(t *IAVLTree, cb func(*IAVLNode) bool) bool {
 	return false
 }
 
+func (node *IAVLNode) traverseInRange(t *IAVLTree, start, end []byte, cb func(*IAVLNode) bool) bool {
+	stop := false
+
+	// make the callback if we are in range
+	// IterateRange ignores this if not leaf
+	if (start == nil || bytes.Compare(start, node.key) <= 0) &&
+		(end == nil || bytes.Compare(node.key, end) <= 0) {
+		stop = cb(node)
+	}
+	if stop {
+		return stop
+	}
+
+	if node.height > 0 {
+		// if the node's key is greater than start, check the left branch
+		if start == nil || bytes.Compare(start, node.key) < 0 {
+			stop = node.getLeftNode(t).traverseInRange(t, start, end, cb)
+		}
+		// abort early if needed...
+		if stop {
+			return stop
+		}
+
+		// if the node's key is lower than stop, check right branch
+		if end == nil || bytes.Compare(node.key, end) < 0 {
+			stop = node.getRightNode(t).traverseInRange(t, start, end, cb)
+		}
+	}
+
+	return stop
+}
+
 // Only used in testing...
 func (node *IAVLNode) lmd(t *IAVLTree) *IAVLNode {
 	if node.height == 0 {

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -158,7 +158,7 @@ func TestUnit(t *testing.T) {
 			t.Fatalf("Expected %v new hashes, got %v", hashCount, count)
 		}
 		// nuke hashes and reconstruct hash, ensure it's the same.
-		tree.root.traverse(tree, func(node *IAVLNode) bool {
+		tree.root.traverse(tree, true, func(node *IAVLNode) bool {
 			node.hash = nil
 			return false
 		})

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -328,8 +328,6 @@ func TestIterateRange(t *testing.T) {
 
 	// insert all the data
 	for _, r := range records {
-		//t.Log("New record", r)
-		//PrintIAVLNode(tree.root)
 		updated := tree.Set([]byte(r.key), []byte(r.value))
 		if updated {
 			t.Error("should have not been updated")

--- a/iavl_test.go
+++ b/iavl_test.go
@@ -352,20 +352,31 @@ func TestIterateRange(t *testing.T) {
 	}
 
 	trav := traverser{}
-	tree.IterateRange([]byte("foo"), []byte("goo"), trav.view)
+	tree.IterateRange([]byte("foo"), []byte("goo"), true, trav.view)
 	expectTraverse(t, trav, "foo", "food", 5)
 
 	trav = traverser{}
-	tree.IterateRange(nil, []byte("flap"), trav.view)
+	tree.IterateRange(nil, []byte("flap"), true, trav.view)
 	expectTraverse(t, trav, "abc", "fan", 2)
 
 	trav = traverser{}
-	tree.IterateRange([]byte("foob"), nil, trav.view)
+	tree.IterateRange([]byte("foob"), nil, true, trav.view)
 	expectTraverse(t, trav, "foobang", "low", 6)
 
 	trav = traverser{}
-	tree.IterateRange([]byte("very"), nil, trav.view)
+	tree.IterateRange([]byte("very"), nil, true, trav.view)
 	expectTraverse(t, trav, "", "", 0)
+
+	// make sure backwards also works...
+	trav = traverser{}
+	tree.IterateRange([]byte("fooba"), []byte("food"), false, trav.view)
+	expectTraverse(t, trav, "food", "foobang", 4)
+
+	// make sure backwards also works...
+	trav = traverser{}
+	tree.IterateRange([]byte("g"), nil, false, trav.view)
+	expectTraverse(t, trav, "low", "good", 2)
+
 }
 
 type traverser struct {

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -170,11 +170,11 @@ func (t *IAVLTree) Iterate(fn func(key []byte, value []byte) bool) (stopped bool
 
 // IterateRange makes a callback for all nodes with key between start and end inclusive
 // If either are nil, then it is open on that side (nil, nil is the same as Iterate)
-func (t *IAVLTree) IterateRange(start, end []byte, fn func(key []byte, value []byte) bool) (stopped bool) {
+func (t *IAVLTree) IterateRange(start, end []byte, ascending bool, fn func(key []byte, value []byte) bool) (stopped bool) {
 	if t.root == nil {
 		return false
 	}
-	return t.root.traverseInRange(t, start, end, func(node *IAVLNode) bool {
+	return t.root.traverseInRange(t, start, end, ascending, func(node *IAVLNode) bool {
 		if node.height == 0 {
 			return fn(node.key, node.value)
 		} else {

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -168,6 +168,21 @@ func (t *IAVLTree) Iterate(fn func(key []byte, value []byte) bool) (stopped bool
 	})
 }
 
+// IterateRange makes a callback for all nodes with key between start and end inclusive
+// If either are nil, then it is open on that side (nil, nil is the same as Iterate)
+func (t *IAVLTree) IterateRange(start, end []byte, fn func(key []byte, value []byte) bool) (stopped bool) {
+	if t.root == nil {
+		return false
+	}
+	return t.root.traverseInRange(t, start, end, func(node *IAVLNode) bool {
+		if node.height == 0 {
+			return fn(node.key, node.value)
+		} else {
+			return false
+		}
+	})
+}
+
 //-----------------------------------------------------------------------------
 
 type nodeDB struct {

--- a/iavl_tree.go
+++ b/iavl_tree.go
@@ -159,7 +159,7 @@ func (t *IAVLTree) Iterate(fn func(key []byte, value []byte) bool) (stopped bool
 	if t.root == nil {
 		return false
 	}
-	return t.root.traverse(t, func(node *IAVLNode) bool {
+	return t.root.traverse(t, true, func(node *IAVLNode) bool {
 		if node.height == 0 {
 			return fn(node.key, node.value)
 		} else {

--- a/types.go
+++ b/types.go
@@ -14,6 +14,7 @@ type Tree interface {
 	Load(hash []byte)
 	Copy() Tree
 	Iterate(func(key []byte, value []byte) (stop bool)) (stopped bool)
+	IterateRange(start []byte, end []byte, ascending bool, fx func(key []byte, value []byte) (stop bool)) (stopped bool)
 }
 
 type Hashable interface {


### PR DESCRIPTION
This IAVL has a nice property that one can sequentially scan through key space. It is often nice to search a range of keys to do a partial index scan (if you give your keys meaning). This pull request exposes an IterateRange method on the tree to complement the Iterate method but without having to scan the entire db.

You can also scan forwards and backward (eg. to easily find first or last in range, even if you don't know their exact values).

Example, I define a proof of existence app.  My merkle key for the files is public_key:file_hash.  Using a iterate range, I can quickly return all files that were claimed by a given public_key, without having to store an arbitrarily long list of file hashes in one node.  This is a recommended technique for building 1:N relationships in key-value stores, and I used it already with Couchbase.

I had pull request #2 sitting for 3 months... Then a develop branch got introduced, so I rebased and updated the pull request.  Please take a look, I am using this in my apps, nice to get it upstream.