### PR TITLE
Add circle.yml to work with dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: test
 
 test:
-	go test `glide novendor`
+	go test -v -race `glide novendor`
 
 bench:
 	go test `glide novendor` -tags gcc -bench=.

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,7 @@
+dependencies:
+  override:
+    - make get_deps
+
+test:
+  override:
+    - make test


### PR DESCRIPTION
Even though all tests pass locally, we get errors in circle CI, due to the dependency on the develop branch of `go-db`.  Here is a circle CI file that **should** fix the issue, so the circle CI tests pass on the main repo.  However, I have no circle CI integration on my repo, so I cannot test that.

Please test this branch and merge it if it fixes the problem.  (Or modify it if needed, so we get nice green checks on the go-merkle repo)