### PR TITLE
Trying to fix circle CI again.  Are they go 1.5?

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,8 @@
 dependencies:
   override:
-    - make get_deps
+    - GOVENDOREXPERIMENT=1 make get_deps
 
 test:
   override:
-    - make test
+    - go version
+    - GOVENDOREXPERIMENT=1 make test


### PR DESCRIPTION
It seems my fix didn't work.  Look at https://circleci.com/gh/tendermint/go-merkle/21

Particularly, expand the sections `make deps` and `make tests`.  All dependencies were installed in vendor, but not found (not even searched) when running.

I guess they must be running go 1.5???

There is a thread about getting them up to go 1.6, about 7 months old, but maybe not updated for this project.  It would be good to fix that as well.
